### PR TITLE
Fix sponsor option in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
       </div>
     </div>
 
-    <div class="site-section">
+    <div class="site-section" id="sponsor">
       <div class="container">
         <div class="row mb-5">
           <div class="col-lg-4 ">


### PR DESCRIPTION
Fix the `Sponsors` link in the navbar to direct to the Sponsors section of the page.